### PR TITLE
Fix enterprise repo file location

### DIFF
--- a/tasks/remove-enterprise-repo.yml
+++ b/tasks/remove-enterprise-repo.yml
@@ -2,5 +2,5 @@
 
 - name: Ensure enterprise repo file is not present
   file:
-    path: /etc/apt/source.list.d/pve-enterprise.list
+    path: /etc/apt/sources.list.d/pve-enterprise.list
     state: absent


### PR DESCRIPTION
Hi, I noticed the path '/etc/apt/source.list.d/pve-enterprise.list' didn't exist, but '/etc/apt/sources.list.d/pve-enterprise.list' does. Perhaps this was a typo?