### PR TITLE
Don't return changed status on pveversion query

### DIFF
--- a/tasks/remove-nag.yml
+++ b/tasks/remove-nag.yml
@@ -4,6 +4,7 @@
     shell: "pveversion | awk -F / '{print $2}'"
     register: pveversion
     check_mode: no
+    changed_when: false
 
   - name: check if backup file exists
     stat:


### PR DESCRIPTION
Ensure task "Get pveversion for backup filename" does not return changed status even if nothing changed.

Gives clean ansible-playbook output with "changed=0" on PLAY RECAP.


BTW - thank you for selfhosted podcast and perfectmediaserver.com - blame you for not having much spare time currently.. ;) 