### PR TITLE
Add No Subscription Repository as a task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 
 remove_nag: True
 remove_enterprise_repo: True
+add_no_subscription_repo: True

--- a/tasks/add-no-subscription-repo.yml
+++ b/tasks/add-no-subscription-repo.yml
@@ -1,0 +1,6 @@
+---
+- name: Add No Subscription Repository
+  apt_repository:
+    repo: deb http://download.proxmox.com/debian/pve buster pve-no-subscription
+    filename: pve-no-subscription
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,5 +9,5 @@
   when: remove_enterprise_repo
 
 - name: add no subcription repo
-  include: add-no-subcription-repo.yml
+  include: add-no-subscription-repo.yml
   when: add_no_subscription_repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,10 @@
   include: remove-nag.yml
   when: remove_nag
 
-- name: remove enterprise repos
+- name: remove enterprise repo
   include: remove-enterprise-repo.yml
   when: remove_enterprise_repo
+
+- name: add no subcription repo
+  include: add-no-subcription-repo.yml
+  when: add_no_subscription_repo


### PR DESCRIPTION
I'm submitting this PR to add the Proxmox no subscription repository as an option for this role. As this role also removes the enterprise repo, it leaves Proxmox in a state that would never be updated, but at least with the no-subscription repository, we could still receive proxmox updates if desired.

The Proxmox No-Subscription repository is meant for testing and non-production use and is popular with Homelabbers.
https://pve.proxmox.com/wiki/Package_Repositories#sysadmin_no_subscription_repo

Adding Ansible output as well as the node below it confirming the addition worked.

![image](https://user-images.githubusercontent.com/783042/120404786-bb0ac080-c30c-11eb-9f7b-ed5364f0a8ea.png)


