### PR TITLE
Fixed to use the replace module

### DIFF
--- a/tasks/remove-nag.yml
+++ b/tasks/remove-nag.yml
@@ -2,7 +2,7 @@
 
 # credit: https://johnscs.com/remove-proxmox51-subscription-notice/ & https://github.com/foundObjects/pve-nag-buster
 - name: Modify line in file to remove nag message
-  regex:
+  replace:
     path: /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
     regexp: "res === null \\|\\| res === undefined \\|\\| !res || res[\\s\\n]*\\.data\\.status\\.toLowerCase\\(\\) !== 'active'"
     replace: "false"


### PR DESCRIPTION
Either I'm really confused about the Ansible versions differences but if I am running the latest one (2.11, 3, 4 or whatever - RedHat seem to be set to confuse everybody) either there's a mistake in the remove-nag.yml file

```
ERROR! couldn't resolve module/action 'regex'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/home/daystorm/.ansible/roles/ironicbadger.ansible_role_proxmox_nag_removal/tasks/remove-nag.yml': line 4, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

# credit: https://johnscs.com/remove-proxmox51-subscription-notice/ & https://github.com/foundObjects/pve-nag-buster
- name: Modify line in file to remove nag message
  ^ here
```

Easy enough fix.