### PR TITLE
Use distro release name to support PVE 6 or 7

### DIFF
--- a/tasks/add-no-subscription-repo.yml
+++ b/tasks/add-no-subscription-repo.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add No Subscription Repository
   apt_repository:
-    repo: deb http://download.proxmox.com/debian/pve buster pve-no-subscription
+    repo: deb http://download.proxmox.com/debian/pve {{ ansible_distribution_release }} pve-no-subscription
     filename: pve-no-subscription
     state: present


### PR DESCRIPTION
This PR adds the use of `{{ ansible_distribution_release }}` in the `add-no-subscription-repo` task so that it works correctly between PVE 6 (buster) and PVE 7 (bullseye).

Closes #14 