### PR TITLE
Change 'include' to 'include_tasks'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: removes subscription nag box
-  include: remove-nag.yml
+  include_tasks: remove-nag.yml
   when: remove_nag
 
 - name: remove enterprise repo
-  include: remove-enterprise-repo.yml
+  include_tasks: remove-enterprise-repo.yml
   when: remove_enterprise_repo
 
 - name: add no subcription repo
-  include: add-no-subscription-repo.yml
+  include_tasks: add-no-subscription-repo.yml
   when: add_no_subscription_repo


### PR DESCRIPTION
Very minor change. 'include' is deprecated and is removed from Ansible version 2.16. [Refer to the docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_module.html#deprecated) for more information.