### PR TITLE
feat: Add option to remove Ceph repo, support Proxmox 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,5 @@
 
 remove_nag: True
 remove_enterprise_repo: True
+remove_ceph_repo: True
 add_no_subscription_repo: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,11 @@
     file: remove-enterprise-repo.yml
   when: remove_enterprise_repo
 
+- name: remove ceph repo
+  include_tasks:
+    file: remove-ceph-repo.yml
+  when: remove_ceph_repo
+
 - name: add no subcription repo
   include_tasks:
     file: add-no-subscription-repo.yml

--- a/tasks/remove-ceph-repo.yml
+++ b/tasks/remove-ceph-repo.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Ensure ceph repo file is not present
+  file:
+    path: /etc/apt/sources.list.d/ceph.list
+    state: absent


### PR DESCRIPTION
This adds a task and related variable to remove the Ceph Apt repository file at `/etc/apt/sources.list.d/ceph.list`. I believe this only exists on PVE 8/Debian 12 but currently causes the `add-no-subscription` task to fail as mentioned in
https://github.com/ironicbadger/ansible-role-proxmox-nag-removal/issues/21.

Note: I've made no attempt to support the no subscription version of the Ceph repository as I expect that most people interested in this are not using Ceph anyway.

Fixes:
* #21